### PR TITLE
ubuntu:latest has some issues installing packages, change to ubuntu:2…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:latest AS base
+FROM ubuntu:20.04 AS base
 
 FROM base AS juce_dev_machine
+
+RUN apt upgrade;apt update
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
Since latest Ubuntu image has some issues installing the packages, a quick and dirty fix is to use ubuntu:20.04 as a base image